### PR TITLE
Add options for internal limit flags

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,20 @@ Note that `--defs` supports being listed multiple times, to handle multiple diff
 luau-analyze --defs=globalTypes.d.lua --defs=extraTypes.d.lua fileToAnalyse.luau
 ```
 
+Limit flags:
+
+These options affect internal limits on the Luau typechecker.\
+Changing these may permit the typechecker to work on complex code at the cost of performance.\
+We don't have good documentation on how these flags affect behavior.\
+Defaults may be listed by running `luau-analyze-rojo --help`
+
+- `--flag:LuauTypeInferRecursionLimit=INT`
+- `--flag:LuauTypeInferIterationLimit=INT`
+- `--flag:LuauTypeInferTypePackLoopLimit=INT`
+- `--flag:LuauCheckRecursionLimit=INT`
+- `--flag:LuauTarjanChildLimit=INT`
+- `--flag:LuauTableTypeMaximumStringifierLength=INT`
+
 ## Registering global types
 
 You can create a definition file to register as global types.

--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ luau-analyze --defs=globalTypes.d.lua --defs=extraTypes.d.lua fileToAnalyse.luau
 
 Limit flags:
 
-These options affect internal limits on the Luau typechecker.\
+These options affect internal limits of the Luau typechecker.\
 Changing these may permit the typechecker to work on complex code at the cost of performance.\
 We don't have good documentation on how these flags affect behavior.\
 Defaults may be listed by running `luau-analyze-rojo --help`

--- a/main.cpp
+++ b/main.cpp
@@ -128,7 +128,7 @@ static void displayHelp(const char* argv0)
     printf("  --exclude-virtual-path: don't include virtual path name in output\n");
     printf("\n");
     printf("Available limit flags:\n");
-    printf("  These options affect internal limits on the Luau typechecker.\n");
+    printf("  These options affect internal limits of the Luau typechecker.\n");
     printf("  Changing these may permit the typechecker to work on complex code at the cost of performance.\n");
     printf("  --flag:LuauTypeInferRecursionLimit=INT:            default %d\n", FInt::LuauTypeInferRecursionLimit.value);
     printf("  --flag:LuauTypeInferIterationLimit=INT:            default %d\n", FInt::LuauTypeInferIterationLimit.value);

--- a/main.cpp
+++ b/main.cpp
@@ -13,6 +13,15 @@
 
 LUAU_FASTFLAG(DebugLuauTimeTracing)
 
+LUAU_FASTINT(LuauTypeInferRecursionLimit)
+LUAU_FASTINT(LuauTypeInferTypePackLoopLimit)
+LUAU_FASTINT(LuauCheckRecursionLimit)
+LUAU_FASTINT(LuauTableTypeMaximumStringifierLength)
+LUAU_FASTINT(LuauTypeInferIterationLimit)
+LUAU_FASTINT(LuauTarjanChildLimit)
+LUAU_FASTFLAG(DebugLuauFreezeArena)
+
+
 enum class ReportFormat
 {
     Default,
@@ -414,6 +423,19 @@ int main(int argc, char** argv)
             globalDefsPaths.push_back(std::string(argv[i] + 7));
         else if (strncmp(argv[i], "--stdin-filepath=", 17) == 0)
             stdinFilepath = std::string(argv[i] + 17);
+
+        else if (strncmp(argv[i], "--limit-infer-recursion=", 24) == 0) // default: 100 (?)
+            FInt::LuauTypeInferRecursionLimit.value = std::stoi(std::string(argv[i] + 24));
+        else if (strncmp(argv[i], "--limit-infer-iteration=", 24) == 0) // default: 2000 (?)
+            FInt::LuauTypeInferIterationLimit.value =  std::stoi(std::string(argv[i] + 24));
+        else if (strncmp(argv[i], "--limit-infer-type-pack-loop=", 29) == 0) // default: 100 (?)
+            FInt::LuauTypeInferTypePackLoopLimit.value =  std::stoi(std::string(argv[i] + 29));
+        else if (strncmp(argv[i], "--limit-check-recursion=", 24) == 0) // default: 100 (?)
+            FInt::LuauCheckRecursionLimit.value =  std::stoi(std::string(argv[i] + 24));
+        else if (strncmp(argv[i], "--limit-tarjan-child=", 21) == 0) // default: 1000 (?)
+            FInt::LuauTarjanChildLimit.value = std::stoi(std::string(argv[i] + 21));
+        else if (strncmp(argv[i], "--limit-max-table-str-len=", 26) == 0) // default: 100 (?)
+            FInt::LuauTableTypeMaximumStringifierLength.value = std::stoi(std::string(argv[i] + 26));
     }
 
 #if !defined(LUAU_ENABLE_TIME_TRACE)

--- a/main.cpp
+++ b/main.cpp
@@ -434,18 +434,18 @@ int main(int argc, char** argv)
         else if (strncmp(argv[i], "--stdin-filepath=", 17) == 0)
             stdinFilepath = std::string(argv[i] + 17);
 
-        else if (strncmp(argv[i], "--flag:LuauTypeInferRecursionLimit=", 36) == 0)
-            FInt::LuauTypeInferRecursionLimit.value = std::stoi(std::string(argv[i] + 36));
-        else if (strncmp(argv[i], "--flag:LuauTypeInferIterationLimit=", 36) == 0)
-            FInt::LuauTypeInferIterationLimit.value =  std::stoi(std::string(argv[i] + 36));
-        else if (strncmp(argv[i], "--flag:LuauTypeInferTypePackLoopLimit=", 39) == 0)
-            FInt::LuauTypeInferTypePackLoopLimit.value =  std::stoi(std::string(argv[i] + 39));
-        else if (strncmp(argv[i], "--flag:LuauCheckRecursionLimit=", 32) == 0)
-            FInt::LuauCheckRecursionLimit.value =  std::stoi(std::string(argv[i] + 32));
-        else if (strncmp(argv[i], "--flag:LuauTarjanChildLimit=", 29) == 0)
-            FInt::LuauTarjanChildLimit.value = std::stoi(std::string(argv[i] + 29));
-        else if (strncmp(argv[i], "--flag:LuauTableTypeMaximumStringifierLength=", 46) == 0)
-            FInt::LuauTableTypeMaximumStringifierLength.value = std::stoi(std::string(argv[i] + 46));
+        else if (strncmp(argv[i], "--flag:LuauTypeInferRecursionLimit=", 31) == 0)
+            FInt::LuauTypeInferRecursionLimit.value = std::stoi(std::string(argv[i] + 31));
+        else if (strncmp(argv[i], "--flag:LuauTypeInferIterationLimit=", 35) == 0)
+            FInt::LuauTypeInferIterationLimit.value =  std::stoi(std::string(argv[i] + 35));
+        else if (strncmp(argv[i], "--flag:LuauTypeInferTypePackLoopLimit=", 38) == 0)
+            FInt::LuauTypeInferTypePackLoopLimit.value =  std::stoi(std::string(argv[i] + 38));
+        else if (strncmp(argv[i], "--flag:LuauCheckRecursionLimit=", 31) == 0)
+            FInt::LuauCheckRecursionLimit.value =  std::stoi(std::string(argv[i] + 31));
+        else if (strncmp(argv[i], "--flag:LuauTarjanChildLimit=", 28) == 0)
+            FInt::LuauTarjanChildLimit.value = std::stoi(std::string(argv[i] + 28));
+        else if (strncmp(argv[i], "--flag:LuauTableTypeMaximumStringifierLength=", 45) == 0)
+            FInt::LuauTableTypeMaximumStringifierLength.value = std::stoi(std::string(argv[i] + 45));
     }
 
 #if !defined(LUAU_ENABLE_TIME_TRACE)

--- a/main.cpp
+++ b/main.cpp
@@ -126,6 +126,16 @@ static void displayHelp(const char* argv0)
     printf("  --stdin-filepath=PATH: path to file being sent through stdin. Used for require resolution\n");
     printf("  --dump-source-map: dump the currently resolved source map\n");
     printf("  --exclude-virtual-path: don't include virtual path name in output\n");
+    printf("\n");
+    printf("Available limit flags:\n");
+    printf("  These options affect internal limits on the Luau typechecker.\n");
+    printf("  Changing these may permit the typechecker to work on complex code at the cost of performance.\n");
+    printf("  --flag:LuauTypeInferRecursionLimit=INT:            default %d\n", FInt::LuauTypeInferRecursionLimit.value);
+    printf("  --flag:LuauTypeInferIterationLimit=INT:            default %d\n", FInt::LuauTypeInferIterationLimit.value);
+    printf("  --flag:LuauTypeInferTypePackLoopLimit=INT:         default %d\n", FInt::LuauTypeInferTypePackLoopLimit.value);
+    printf("  --flag:LuauCheckRecursionLimit=INT:                default %d\n", FInt::LuauCheckRecursionLimit.value);
+    printf("  --flag:LuauTarjanChildLimit=INT:                   default %d\n", FInt::LuauTarjanChildLimit.value);
+    printf("  --flag:LuauTableTypeMaximumStringifierLength=INT:  default %d\n", FInt::LuauTableTypeMaximumStringifierLength.value);
 }
 
 static int assertionHandler(const char* expr, const char* file, int line, const char* function)
@@ -424,18 +434,18 @@ int main(int argc, char** argv)
         else if (strncmp(argv[i], "--stdin-filepath=", 17) == 0)
             stdinFilepath = std::string(argv[i] + 17);
 
-        else if (strncmp(argv[i], "--limit-infer-recursion=", 24) == 0) // default: 100 (?)
-            FInt::LuauTypeInferRecursionLimit.value = std::stoi(std::string(argv[i] + 24));
-        else if (strncmp(argv[i], "--limit-infer-iteration=", 24) == 0) // default: 2000 (?)
-            FInt::LuauTypeInferIterationLimit.value =  std::stoi(std::string(argv[i] + 24));
-        else if (strncmp(argv[i], "--limit-infer-type-pack-loop=", 29) == 0) // default: 100 (?)
-            FInt::LuauTypeInferTypePackLoopLimit.value =  std::stoi(std::string(argv[i] + 29));
-        else if (strncmp(argv[i], "--limit-check-recursion=", 24) == 0) // default: 100 (?)
-            FInt::LuauCheckRecursionLimit.value =  std::stoi(std::string(argv[i] + 24));
-        else if (strncmp(argv[i], "--limit-tarjan-child=", 21) == 0) // default: 1000 (?)
-            FInt::LuauTarjanChildLimit.value = std::stoi(std::string(argv[i] + 21));
-        else if (strncmp(argv[i], "--limit-max-table-str-len=", 26) == 0) // default: 100 (?)
-            FInt::LuauTableTypeMaximumStringifierLength.value = std::stoi(std::string(argv[i] + 26));
+        else if (strncmp(argv[i], "--flag:LuauTypeInferRecursionLimit=", 36) == 0)
+            FInt::LuauTypeInferRecursionLimit.value = std::stoi(std::string(argv[i] + 36));
+        else if (strncmp(argv[i], "--flag:LuauTypeInferIterationLimit=", 36) == 0)
+            FInt::LuauTypeInferIterationLimit.value =  std::stoi(std::string(argv[i] + 36));
+        else if (strncmp(argv[i], "--flag:LuauTypeInferTypePackLoopLimit=", 39) == 0)
+            FInt::LuauTypeInferTypePackLoopLimit.value =  std::stoi(std::string(argv[i] + 39));
+        else if (strncmp(argv[i], "--flag:LuauCheckRecursionLimit=", 32) == 0)
+            FInt::LuauCheckRecursionLimit.value =  std::stoi(std::string(argv[i] + 32));
+        else if (strncmp(argv[i], "--flag:LuauTarjanChildLimit=", 29) == 0)
+            FInt::LuauTarjanChildLimit.value = std::stoi(std::string(argv[i] + 29));
+        else if (strncmp(argv[i], "--flag:LuauTableTypeMaximumStringifierLength=", 46) == 0)
+            FInt::LuauTableTypeMaximumStringifierLength.value = std::stoi(std::string(argv[i] + 46));
     }
 
 #if !defined(LUAU_ENABLE_TIME_TRACE)

--- a/main.cpp
+++ b/main.cpp
@@ -434,8 +434,8 @@ int main(int argc, char** argv)
         else if (strncmp(argv[i], "--stdin-filepath=", 17) == 0)
             stdinFilepath = std::string(argv[i] + 17);
 
-        else if (strncmp(argv[i], "--flag:LuauTypeInferRecursionLimit=", 31) == 0)
-            FInt::LuauTypeInferRecursionLimit.value = std::stoi(std::string(argv[i] + 31));
+        else if (strncmp(argv[i], "--flag:LuauTypeInferRecursionLimit=", 35) == 0)
+            FInt::LuauTypeInferRecursionLimit.value = std::stoi(std::string(argv[i] + 35));
         else if (strncmp(argv[i], "--flag:LuauTypeInferIterationLimit=", 35) == 0)
             FInt::LuauTypeInferIterationLimit.value =  std::stoi(std::string(argv[i] + 35));
         else if (strncmp(argv[i], "--flag:LuauTypeInferTypePackLoopLimit=", 38) == 0)
@@ -446,6 +446,13 @@ int main(int argc, char** argv)
             FInt::LuauTarjanChildLimit.value = std::stoi(std::string(argv[i] + 28));
         else if (strncmp(argv[i], "--flag:LuauTableTypeMaximumStringifierLength=", 45) == 0)
             FInt::LuauTableTypeMaximumStringifierLength.value = std::stoi(std::string(argv[i] + 45));
+            
+        printf("  --flag:LuauTypeInferRecursionLimit=INT:            value %d\n", FInt::LuauTypeInferRecursionLimit.value);
+        printf("  --flag:LuauTypeInferIterationLimit=INT:            value %d\n", FInt::LuauTypeInferIterationLimit.value);
+        printf("  --flag:LuauTypeInferTypePackLoopLimit=INT:         value %d\n", FInt::LuauTypeInferTypePackLoopLimit.value);
+        printf("  --flag:LuauCheckRecursionLimit=INT:                value %d\n", FInt::LuauCheckRecursionLimit.value);
+        printf("  --flag:LuauTarjanChildLimit=INT:                   value %d\n", FInt::LuauTarjanChildLimit.value);
+        printf("  --flag:LuauTableTypeMaximumStringifierLength=INT:  value %d\n", FInt::LuauTableTypeMaximumStringifierLength.value);
     }
 
 #if !defined(LUAU_ENABLE_TIME_TRACE)

--- a/main.cpp
+++ b/main.cpp
@@ -446,13 +446,6 @@ int main(int argc, char** argv)
             FInt::LuauTarjanChildLimit.value = std::stoi(std::string(argv[i] + 28));
         else if (strncmp(argv[i], "--flag:LuauTableTypeMaximumStringifierLength=", 45) == 0)
             FInt::LuauTableTypeMaximumStringifierLength.value = std::stoi(std::string(argv[i] + 45));
-            
-        printf("  --flag:LuauTypeInferRecursionLimit=INT:            value %d\n", FInt::LuauTypeInferRecursionLimit.value);
-        printf("  --flag:LuauTypeInferIterationLimit=INT:            value %d\n", FInt::LuauTypeInferIterationLimit.value);
-        printf("  --flag:LuauTypeInferTypePackLoopLimit=INT:         value %d\n", FInt::LuauTypeInferTypePackLoopLimit.value);
-        printf("  --flag:LuauCheckRecursionLimit=INT:                value %d\n", FInt::LuauCheckRecursionLimit.value);
-        printf("  --flag:LuauTarjanChildLimit=INT:                   value %d\n", FInt::LuauTarjanChildLimit.value);
-        printf("  --flag:LuauTableTypeMaximumStringifierLength=INT:  value %d\n", FInt::LuauTableTypeMaximumStringifierLength.value);
     }
 
 #if !defined(LUAU_ENABLE_TIME_TRACE)


### PR DESCRIPTION
This PR adds options for internal limits. Raising these limits may allow the typechecker to work on code that usually errors with `Internal error: Code is too complex to typecheck!`.

This PR introduces a new format for flags so that we can potentially be forward-compatible with general flag commands that allow setting any flag to any value. This new format contains the internal flag name in the commandline option so that we won't be stuck eternally hard-coding `kebab-case` options to `PascalCase` flags.

This new format looks like: `--flag:LuauFlagName=value`

I don't have good documentation on what these flags do. I just know that they're typically all listed together.

Closes #11